### PR TITLE
Update to v0.9.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/boostsecurityio/poutine:0.9.7@sha256:034326fac021cbedf8df99e90d993ec3553c7649395040bbb8bca05b601de35a
+FROM ghcr.io/boostsecurityio/poutine:0.9.9@sha256:e5790a12cb19c1433fee835e7b03f9e4051efb872bfc3d1c2a555767fbb65a70
 
 USER root
 


### PR DESCRIPTION
```
docker buildx imagetools inspect ghcr.io/boostsecurityio/poutine:0.9.9                                                          main
Name:      ghcr.io/boostsecurityio/poutine:0.9.9
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:e5790a12cb19c1433fee835e7b03f9e4051efb872bfc3d1c2a555767fbb65a70
```