### PR TITLE
Update action to v0.9.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/boostsecurityio/poutine:0.9.9@sha256:e5790a12cb19c1433fee835e7b03f9e4051efb872bfc3d1c2a555767fbb65a70
+FROM ghcr.io/boostsecurityio/poutine:0.9.10@sha256:74856385aadf2873389fcaac676551c7c7315d13e744d06fd645890e7794c6e7
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # poutine-action
-boostsecurityio/poutine-action
+
+This is a simple GitHub Action to simplify using poutine as part of GitHub Actions workflows.
+
+Created by BoostSecurity.io, poutine is a security scanner that detects misconfigurations and vulnerabilities in the build pipelines of a repository. It supports parsing CI workflows from GitHub Actions and Gitlab CI/CD. When given an access token with read-level access, poutine can analyze all the repositories of an organization to quickly gain insights into the security posture of the organization's software supply chain.
+
+Visit https://github.com/boostsecurityio/poutine for more details about poutine itself.


### PR DESCRIPTION
Also updated the README

```
$ docker buildx imagetools inspect ghcr.io/boostsecurityio/poutine:0.9.10                                                         main
Name:      ghcr.io/boostsecurityio/poutine:0.9.10
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:74856385aadf2873389fcaac676551c7c7315d13e744d06fd645890e7794c6e7

Manifests:
  Name:      ghcr.io/boostsecurityio/poutine:0.9.10@sha256:a223748eafd7760b5653f7562d5e013d94c1f5dec854b8600e2d0fbcb4ae3360
  MediaType: application/vnd.oci.image.manifest.v1+json
  Platform:  linux/amd64

  Name:      ghcr.io/boostsecurityio/poutine:0.9.10@sha256:8724c3a482bb0498f6d4dbd15f361c20c5c473742d08824d9a9b3792706f7933
  MediaType: application/vnd.oci.image.manifest.v1+json
  Platform:  linux/arm64

$ docker run ghcr.io/boostsecurityio/poutine:0.9.10@sha256:74856385aadf2873389fcaac676551c7c7315d13e744d06fd645890e7794c6e7       main
Unable to find image 'ghcr.io/boostsecurityio/poutine:0.9.10@sha256:74856385aadf2873389fcaac676551c7c7315d13e744d06fd645890e7794c6e7' locally
ghcr.io/boostsecurityio/poutine@sha256:74856385aadf2873389fcaac676551c7c7315d13e744d06fd645890e7794c6e7: Pulling from boostsecurityio/poutine
020521acb90c: Already exists
250c06f7c38e: Already exists
dbc40a9696bb: Pull complete
Digest: sha256:74856385aadf2873389fcaac676551c7c7315d13e744d06fd645890e7794c6e7
Status: Downloaded newer image for ghcr.io/boostsecurityio/poutine@sha256:74856385aadf2873389fcaac676551c7c7315d13e744d06fd645890e7794c6e7
poutine - A Supply Chain Vulnerability Scanner for Build Pipelines
By BoostSecurity.io - https://github.com/boostsecurityio/poutine

Usage:
  poutine [options] <command> [<args>]

Commands:
  analyze_org <org>
  analyze_repo <org>/<repo>
  analyze_local <path>

Options:
  -format string
    	Output format (pretty, json, sarif) (default "pretty")
  -scm string
    	SCM platform (github, gitlab) (default "github")
  -scm-base-url string
    	Base URI of the self-hosted SCM instance (optional)
  -threads int
    	Parallelization factor for scanning organizations (default 2)
  -token string
    	SCM access token (required for the commands analyze_org, analyze_repo) (env: GH_TOKEN)
  -verbose
    	Enable verbose logging