### PR TITLE
[codex] Update poutine action to v1.1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/boostsecurityio/poutine:1.1.2@sha256:d90a3bdab514c6a8eff7062d9dd1afbfbce0a79b77d99430553afe8acbbfa108
+FROM ghcr.io/boostsecurityio/poutine:1.1.3@sha256:26bb938d0b8784c966fa6faf39d9f096b5072a29f283be041b494ad1b8eabc8e
 
 USER root
 


### PR DESCRIPTION
## What changed
- bump the `ghcr.io/boostsecurityio/poutine` image pin in `Dockerfile` from `1.1.2` to `1.1.3`
- update the pinned multi-arch manifest digest to `sha256:26bb938d0b8784c966fa6faf39d9f096b5072a29f283be041b494ad1b8eabc8e`

## Why
- align this GitHub Action wrapper with the upstream `poutine` `v1.1.3` release

## Impact
- workflows using this action will run the `poutine` `1.1.3` CLI image

## Validation
- resolved the upstream `1.1.3` image digest from GHCR with `crane digest`
- reviewed the resulting single-line `Dockerfile` diff