### PR TITLE
Update poutine action to v1.1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/boostsecurityio/poutine:1.1.3@sha256:26bb938d0b8784c966fa6faf39d9f096b5072a29f283be041b494ad1b8eabc8e
+FROM ghcr.io/boostsecurityio/poutine:1.1.4@sha256:c7f2ffa1516372b9f6b8e0b59fd0e91a2a043ab7d0741654166fbda6d41338cd
 
 USER root
 


### PR DESCRIPTION
## What changed
- bump the `ghcr.io/boostsecurityio/poutine` image pin in `Dockerfile` from `1.1.3` to `1.1.4`
- update the pinned multi-arch manifest digest to `sha256:c7f2ffa1516372b9f6b8e0b59fd0e91a2a043ab7d0741654166fbda6d41338cd`

## Why
- align this GitHub Action wrapper with the upstream `poutine` `v1.1.4` release

## Impact
- workflows using this action will run the `poutine` `1.1.4` CLI image

## Validation
- resolved the upstream `1.1.4` image digest from GHCR with `docker buildx imagetools inspect`
- reviewed the resulting single-line `Dockerfile` diff

Signed-off-by: graelo <graelo@graelo.cc>